### PR TITLE
Deprecated string ref.

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ class NotificationAlert extends React.Component {
     };
     this.onDismiss = this.onDismiss.bind(this);
     this.notificationAlert = this.notificationAlert.bind(this);
+    this.refNotification = React.createRef();
   }
   // to stop the warning of calling setState of unmounted component
   componentWillUnmount() {
@@ -179,7 +180,7 @@ class NotificationAlert extends React.Component {
   render() {
     return React.createElement(
       "div",
-      { ref: "notifications" },
+      { ref: this.refNotification },
       this.showAllNotifications("tl"),
       this.showAllNotifications("tc"),
       this.showAllNotifications("tr"),


### PR DESCRIPTION
**Warning in strict mode React  16.13.1**

If you worked with React before, you might be familiar with an older API where the _ref_ attribute is a string, like _"textInput"_, and the DOM node is accessed as _this.refs.textInput_. We advise against it because string refs have **some issues**, are considered legacy, _**and are likely to be removed in one of the future releases**_.

[https://reactjs.org/docs/refs-and-the-dom.html#legacy-api-string-refs](https://reactjs.org/docs/refs-and-the-dom.html#legacy-api-string-refs)